### PR TITLE
fix: 修复README中的Star History图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@
 ![微信公众号二维码--随缘](using_files/wechat/self_qr.png)
 
 ### *Star History*
-[![Star History Chart](https://api.star-history.com/svg?repos=aceliuchanghong/FAQ_Of_LLM_Interview&type=Date)](https://www.star-history.com/#aceliuchanghong/FAQ_Of_LLM_Interview&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=aceliuchanghong/FAQ_Of_LLM_Interview&type=Date)](https://star-history.dera.page/#aceliuchanghong/FAQ_Of_LLM_Interview&type=Date)


### PR DESCRIPTION
README中的Star History图表目前因原服务的数据源问题已经无法正常显示,影响了仓库的展示效果。本次更新将图表端点切换到可用的替代服务,并保持原有参数不变,欢迎合入。